### PR TITLE
Jobs website extraction

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.9.3
+  rev: v0.9.6
   hooks:
     - id: ruff
       args: [ --fix ]

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from fake_zyte_api.main import make_app
+
+if TYPE_CHECKING:
+    from aiohttp.pytest_plugin import AiohttpClient, AiohttpServer
+    from aiohttp.test_utils import TestClient, TestServer
+    from aiohttp.web import Application, Request
+
+
+@pytest.fixture
+async def api_client(
+    aiohttp_client: AiohttpClient,
+) -> TestClient[Request, Application]:
+    app = make_app()
+    return await aiohttp_client(app)
+
+
+@pytest.fixture
+async def jobs_website(aiohttp_server: AiohttpServer) -> TestServer:
+    from zyte_test_websites.jobs.app import make_app
+    from zyte_test_websites.utils import get_default_data
+
+    app = make_app(get_default_data("jobs"))
+    return await aiohttp_server(app)

--- a/conftest.py
+++ b/conftest.py
@@ -13,6 +13,12 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
+async def api_server(aiohttp_server: AiohttpServer) -> TestServer:
+    app = make_app()
+    return await aiohttp_server(app)
+
+
+@pytest.fixture
 async def api_client(
     aiohttp_client: AiohttpClient,
 ) -> TestClient[Request, Application]:

--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
+from zyte_test_websites.jobs.app import make_app as make_test_job_website
+from zyte_test_websites.utils import get_default_data
 
 from fake_zyte_api.main import make_app
 
@@ -28,8 +30,5 @@ async def api_client(
 
 @pytest.fixture
 async def jobs_website(aiohttp_server: AiohttpServer) -> TestServer:
-    from zyte_test_websites.jobs.app import make_app
-    from zyte_test_websites.utils import get_default_data
-
-    app = make_app(get_default_data("jobs"))
+    app = make_test_job_website(get_default_data("jobs"))
     return await aiohttp_server(app)

--- a/fake_zyte_api/api.py
+++ b/fake_zyte_api/api.py
@@ -1,5 +1,45 @@
+from __future__ import annotations
+
+from base64 import b64encode
 from typing import Any
 
+import aiohttp
+from itemadapter import ItemAdapter
+from web_poet import HttpResponse
+from zyte_common_items import ZyteItemAdapter
+from zyte_test_websites.jobs.extraction import (
+    TestJobPostingNavigationPage,
+    TestJobPostingPage,
+)
 
-def handle_request(data: dict[str, Any]) -> dict[str, Any]:
-    return {}
+ItemAdapter.ADAPTER_CLASSES.appendleft(ZyteItemAdapter)  # type: ignore[attr-defined]
+
+
+async def handle_request(request_data: dict[str, Any]) -> dict[str, Any]:
+    url = request_data["url"]
+    response_data: dict[str, Any] = {
+        "url": url,
+    }
+
+    async with aiohttp.ClientSession() as session, session.get(url) as resp:
+        website_response_body = await resp.read()
+
+    if "httpResponseBody" in request_data:
+        body_b64 = b64encode(website_response_body).decode()
+        response_data["httpResponseBody"] = body_b64
+
+    if "jobPostingNavigation" in request_data:
+        web_poet_response = HttpResponse(url, website_response_body)
+        job_posting_nav_page = TestJobPostingNavigationPage(web_poet_response)
+        job_posting_navigation = await job_posting_nav_page.to_item()
+        response_data["jobPostingNavigation"] = ItemAdapter(
+            job_posting_navigation
+        ).asdict()
+
+    if "jobPosting" in request_data:
+        web_poet_response = HttpResponse(url, website_response_body)
+        job_posting_page = TestJobPostingPage(web_poet_response)
+        job_posting = await job_posting_page.to_item()
+        response_data["jobPosting"] = ItemAdapter(job_posting).asdict()
+
+    return response_data

--- a/fake_zyte_api/api.py
+++ b/fake_zyte_api/api.py
@@ -28,6 +28,9 @@ async def handle_request(request_data: dict[str, Any]) -> dict[str, Any]:
         body_b64 = b64encode(website_response_body).decode()
         response_data["httpResponseBody"] = body_b64
 
+    if "browserHtml" in request_data:
+        response_data["browserHtml"] = website_response_body.decode(resp.get_encoding())
+
     if "jobPostingNavigation" in request_data:
         web_poet_response = HttpResponse(url, website_response_body)
         job_posting_nav_page = TestJobPostingNavigationPage(web_poet_response)

--- a/fake_zyte_api/api.py
+++ b/fake_zyte_api/api.py
@@ -22,6 +22,7 @@ async def handle_request(request_data: dict[str, Any]) -> dict[str, Any]:
     }
 
     async with aiohttp.ClientSession() as session, session.get(url) as resp:
+        response_data["statusCode"] = resp.status
         website_response_body = await resp.read()
 
     if "httpResponseBody" in request_data:

--- a/fake_zyte_api/main.py
+++ b/fake_zyte_api/main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 from aiohttp import web
@@ -7,11 +9,17 @@ from .api import handle_request
 routes = web.RouteTableDef()
 
 
-@routes.get("/extract")
+@routes.post("/extract")
 async def extract(request: web.Request) -> web.Response:
     req_data = await request.json()
-    resp_data = handle_request(req_data)
+    resp_data = await handle_request(req_data)
     return web.json_response(resp_data)
+
+
+def make_app() -> web.Application:
+    app = web.Application()
+    app.add_routes(routes)
+    return app
 
 
 if __name__ == "__main__":
@@ -21,6 +29,5 @@ if __name__ == "__main__":
 
     port = int(sys.argv[1])
     print(f"Endpoint: http://127.0.0.1:{port}/extract")
-    app = web.Application()
-    app.add_routes(routes)
+    app = make_app()
     web.run_app(app, port=port)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,10 @@ authors = [{name = "Zyte Group Ltd", email = "info@zyte.com"}]
 readme = "README.rst"
 dependencies = [
     "aiohttp >= 3.9.0",
+    "itemadapter >= 0.8.0",
+    "web-poet >= 0.14.0",
+    "zyte-common-items >= 0.24.0",
+    "zyte-test-websites @ git+https://github.com/zytedata/zyte-test-websites@main",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -149,7 +153,7 @@ ignore = [
     # Magic value used in comparison
     "PLR2004",
     # Use of `assert` detected
-    "S101"
+    "S101",
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,10 @@ version = {attr = "fake_zyte_api.__version__"}
 fake_zyte_api = ["py.typed"]
 
 [[tool.mypy.overrides]]
+module = "zyte_api"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
 module = "tests.*"
 check_untyped_defs = true
 allow_untyped_defs = true

--- a/tests/test_direct.py
+++ b/tests/test_direct.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from base64 import b64decode
 from typing import TYPE_CHECKING, Any
 
-from yarl import URL
-
 if TYPE_CHECKING:
     from aiohttp import ClientResponse
     from aiohttp.test_utils import TestClient
@@ -15,6 +13,24 @@ async def get_api_response(
     client: TestClient[Request, Application], request_data: dict[str, Any]
 ) -> ClientResponse:
     return await client.post("/extract", json=request_data)
+
+
+async def test_404(api_client, jobs_website):
+    url = str(jobs_website.make_url("/nonexistent"))
+    response = await get_api_response(
+        api_client,
+        {
+            "url": url,
+            "httpResponseBody": True,
+        },
+    )
+    assert response.status == 200
+    response_data = await response.json()
+    assert response_data["url"] == url
+    assert response_data["statusCode"] == 404
+    assert "httpResponseBody" in response_data
+    text = b64decode(response_data["httpResponseBody"]).decode("utf-8")
+    assert "404: Not Found" in text
 
 
 async def test_response_body(api_client, jobs_website):
@@ -29,6 +45,7 @@ async def test_response_body(api_client, jobs_website):
     assert response.status == 200
     response_data = await response.json()
     assert response_data["url"] == url
+    assert response_data["statusCode"] == 200
     assert "httpResponseBody" in response_data
 
     text = b64decode(response_data["httpResponseBody"]).decode("utf-8")
@@ -51,11 +68,12 @@ async def test_browser_html(api_client, jobs_website):
     assert response.status == 200
     response_data = await response.json()
     assert response_data["url"] == url
+    assert response_data["statusCode"] == 200
     assert "browserHtml" in response_data
     assert "<h1>109 jobs in Energy:</h1>" in response_data["browserHtml"]
 
 
-async def test_extract_job_posting(api_client, jobs_website):
+async def test_extraction_with_body(api_client, jobs_website):
     url = str(jobs_website.make_url("/job/1888448280485890"))
     response = await get_api_response(
         api_client,
@@ -68,83 +86,33 @@ async def test_extract_job_posting(api_client, jobs_website):
     assert response.status == 200
     response_data = await response.json()
     assert response_data["url"] == url
+    assert response_data["statusCode"] == 200
 
     assert "httpResponseBody" in response_data
     text = b64decode(response_data["httpResponseBody"]).decode("utf-8")
     assert "<h1>Litigation Attorney</h1>" in text
-    assert '<span class="job-location">Bogotá, Colombia</span>' in text
 
     assert "jobPosting" in response_data
     job_posting = response_data["jobPosting"]
-    descr = (
-        "Family Law Attorneys deal with legal matters related to family"
-        " relationships. They handle cases like divorce, child custody,"
-        " adoption, and domestic disputes to provide legal guidance."
-    )
-    assert job_posting == {
-        "url": url,
-        "datePublished": "2023-09-07T00:00:00Z",
-        "datePublishedRaw": "Sep 07, 2023",
-        "jobTitle": "Litigation Attorney",
-        "jobLocation": {"raw": "Bogotá, Colombia"},
-        "description": descr,
-        "descriptionHtml": f"<article>\n\n<p>{descr}</p>\n\n</article>",
-        "employmentType": "Contract",
-        "baseSalary": {"valueMin": "63K", "valueMax": "101K", "currency": "USD"},
-        "requirements": ["4 to 10 Years"],
-        "hiringOrganization": {"name": "Drax Group"},
-        "metadata": {
-            "dateDownloaded": job_posting["metadata"]["dateDownloaded"],
-            "probability": 1.0,
-        },
-    }
+    assert job_posting["jobTitle"] == "Litigation Attorney"
 
 
-async def test_extract_job_posting_nav(api_client, jobs_website):
-    url = jobs_website.make_url("/jobs/4")
+async def test_extraction_without_body(api_client, jobs_website):
+    url = str(jobs_website.make_url("/job/1888448280485890"))
     response = await get_api_response(
         api_client,
         {
-            "url": str(url),
-            "httpResponseBody": True,
-            "jobPostingNavigation": True,
+            "url": url,
+            "jobPosting": True,
         },
     )
     assert response.status == 200
     response_data = await response.json()
-    assert response_data["url"] == str(url)
+    assert response_data["url"] == url
+    assert response_data["statusCode"] == 200
 
-    assert "httpResponseBody" in response_data
-    text = b64decode(response_data["httpResponseBody"]).decode("utf-8")
-    assert "<h1>109 jobs in Energy:</h1>" in text
+    assert "httpResponseBody" not in response_data
 
-    assert "jobPostingNavigation" in response_data
-    job_posting_navigation = response_data["jobPostingNavigation"]
-    jobs = [
-        ("1888448280485890", "Litigation Attorney"),
-        ("1583065288960216", "Interior Designer"),
-        ("2505213971303748", "IT Administrator"),
-        ("2973702198556912", "Digital Marketing Specialist"),
-        ("160399666386920", "Legal Assistant"),
-        ("2226428310491314", "Customer Support Specialist"),
-        ("2962173505197183", "Substance Abuse Counselor"),
-        ("895360732760260", "Social Media Manager"),
-        ("360775924046834", "Procurement Manager"),
-        ("1939835498099785", "Physician Assistant"),
-    ]
-    assert job_posting_navigation == {
-        "url": str(url),
-        "items": [
-            {
-                "url": str(url.join(URL(f"/job/{job[0]}"))),
-                "method": "GET",
-                "name": job[1],
-            }
-            for job in jobs
-        ],
-        "nextPage": {"url": str(url.join(URL("/jobs/4?page=2"))), "method": "GET"},
-        "pageNumber": 1,
-        "metadata": {
-            "dateDownloaded": job_posting_navigation["metadata"]["dateDownloaded"]
-        },
-    }
+    assert "jobPosting" in response_data
+    job_posting = response_data["jobPosting"]
+    assert job_posting["jobTitle"] == "Litigation Attorney"

--- a/tests/test_direct.py
+++ b/tests/test_direct.py
@@ -39,6 +39,22 @@ async def test_response_body(api_client, jobs_website):
     assert 'href="/jobs/4?page=2">Next' in text
 
 
+async def test_browser_html(api_client, jobs_website):
+    url = str(jobs_website.make_url("/jobs/4"))
+    response = await get_api_response(
+        api_client,
+        {
+            "url": url,
+            "browserHtml": True,
+        },
+    )
+    assert response.status == 200
+    response_data = await response.json()
+    assert response_data["url"] == url
+    assert "browserHtml" in response_data
+    assert "<h1>109 jobs in Energy:</h1>" in response_data["browserHtml"]
+
+
 async def test_extract_job_posting(api_client, jobs_website):
     url = str(jobs_website.make_url("/job/1888448280485890"))
     response = await get_api_response(

--- a/tests/test_direct.py
+++ b/tests/test_direct.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from base64 import b64decode
+from typing import TYPE_CHECKING, Any
+
+from yarl import URL
+
+if TYPE_CHECKING:
+    from aiohttp import ClientResponse
+    from aiohttp.test_utils import TestClient
+    from aiohttp.web import Application, Request
+
+
+async def get_api_response(
+    client: TestClient[Request, Application], request_data: dict[str, Any]
+) -> ClientResponse:
+    return await client.post("/extract", json=request_data)
+
+
+async def test_response_body(api_client, jobs_website):
+    url = str(jobs_website.make_url("/jobs/4"))
+    response = await get_api_response(
+        api_client,
+        {
+            "url": url,
+            "httpResponseBody": True,
+        },
+    )
+    assert response.status == 200
+    response_data = await response.json()
+    assert response_data["url"] == url
+    assert "httpResponseBody" in response_data
+
+    text = b64decode(response_data["httpResponseBody"]).decode("utf-8")
+    assert "<h1>109 jobs in Energy:</h1>" in text
+    assert (
+        '<a class="job-link" href="/job/1583065288960216">Interior Designer</a>' in text
+    )
+    assert 'href="/jobs/4?page=2">Next' in text
+
+
+async def test_extract_job_posting(api_client, jobs_website):
+    url = str(jobs_website.make_url("/job/1888448280485890"))
+    response = await get_api_response(
+        api_client,
+        {
+            "url": url,
+            "httpResponseBody": True,
+            "jobPosting": True,
+        },
+    )
+    assert response.status == 200
+    response_data = await response.json()
+    assert response_data["url"] == url
+
+    assert "httpResponseBody" in response_data
+    text = b64decode(response_data["httpResponseBody"]).decode("utf-8")
+    assert "<h1>Litigation Attorney</h1>" in text
+    assert '<span class="job-location">Bogotá, Colombia</span>' in text
+
+    assert "jobPosting" in response_data
+    job_posting = response_data["jobPosting"]
+    descr = (
+        "Family Law Attorneys deal with legal matters related to family"
+        " relationships. They handle cases like divorce, child custody,"
+        " adoption, and domestic disputes to provide legal guidance."
+    )
+    assert job_posting == {
+        "url": url,
+        "datePublished": "2023-09-07T00:00:00Z",
+        "datePublishedRaw": "Sep 07, 2023",
+        "jobTitle": "Litigation Attorney",
+        "jobLocation": {"raw": "Bogotá, Colombia"},
+        "description": descr,
+        "descriptionHtml": f"<article>\n\n<p>{descr}</p>\n\n</article>",
+        "employmentType": "Contract",
+        "baseSalary": {"valueMin": "63K", "valueMax": "101K", "currency": "USD"},
+        "requirements": ["4 to 10 Years"],
+        "hiringOrganization": {"name": "Drax Group"},
+        "metadata": {
+            "dateDownloaded": job_posting["metadata"]["dateDownloaded"],
+            "probability": 1.0,
+        },
+    }
+
+
+async def test_extract_job_posting_nav(api_client, jobs_website):
+    url = jobs_website.make_url("/jobs/4")
+    response = await get_api_response(
+        api_client,
+        {
+            "url": str(url),
+            "httpResponseBody": True,
+            "jobPostingNavigation": True,
+        },
+    )
+    assert response.status == 200
+    response_data = await response.json()
+    assert response_data["url"] == str(url)
+
+    assert "httpResponseBody" in response_data
+    text = b64decode(response_data["httpResponseBody"]).decode("utf-8")
+    assert "<h1>109 jobs in Energy:</h1>" in text
+
+    assert "jobPostingNavigation" in response_data
+    job_posting_navigation = response_data["jobPostingNavigation"]
+    jobs = [
+        ("1888448280485890", "Litigation Attorney"),
+        ("1583065288960216", "Interior Designer"),
+        ("2505213971303748", "IT Administrator"),
+        ("2973702198556912", "Digital Marketing Specialist"),
+        ("160399666386920", "Legal Assistant"),
+        ("2226428310491314", "Customer Support Specialist"),
+        ("2962173505197183", "Substance Abuse Counselor"),
+        ("895360732760260", "Social Media Manager"),
+        ("360775924046834", "Procurement Manager"),
+        ("1939835498099785", "Physician Assistant"),
+    ]
+    assert job_posting_navigation == {
+        "url": str(url),
+        "items": [
+            {
+                "url": str(url.join(URL(f"/job/{job[0]}"))),
+                "method": "GET",
+                "name": job[1],
+            }
+            for job in jobs
+        ],
+        "nextPage": {"url": str(url.join(URL("/jobs/4?page=2"))), "method": "GET"},
+        "pageNumber": 1,
+        "metadata": {
+            "dateDownloaded": job_posting_navigation["metadata"]["dateDownloaded"]
+        },
+    }

--- a/tests/test_zyte_api.py
+++ b/tests/test_zyte_api.py
@@ -30,6 +30,15 @@ async def test_response_body(zyte_api_client, jobs_website):
     assert 'href="/jobs/4?page=2">Next' in text
 
 
+async def test_browser_html(zyte_api_client, jobs_website):
+    url = str(jobs_website.make_url("/jobs/4"))
+    response_data = await zyte_api_client.get({"url": url, "browserHtml": True})
+    assert response_data["url"] == url
+
+    assert "browserHtml" in response_data
+    assert "<h1>109 jobs in Energy:</h1>" in response_data["browserHtml"]
+
+
 async def test_extract_job_posting(zyte_api_client, jobs_website):
     url = str(jobs_website.make_url("/job/1888448280485890"))
     response_data = await zyte_api_client.get(

--- a/tests/test_zyte_api.py
+++ b/tests/test_zyte_api.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from base64 import b64decode
+from typing import TYPE_CHECKING
+
+import pytest
+from yarl import URL
+from zyte_api import AsyncZyteAPI
+
+if TYPE_CHECKING:
+    from aiohttp.test_utils import TestServer
+
+
+@pytest.fixture
+def zyte_api_client(api_server: TestServer) -> AsyncZyteAPI:
+    return AsyncZyteAPI(api_key="a", api_url=str(api_server.make_url("/")))
+
+
+async def test_response_body(zyte_api_client, jobs_website):
+    url = str(jobs_website.make_url("/jobs/4"))
+    response_data = await zyte_api_client.get({"url": url, "httpResponseBody": True})
+    assert response_data["url"] == url
+
+    assert "httpResponseBody" in response_data
+    text = b64decode(response_data["httpResponseBody"]).decode("utf-8")
+    assert "<h1>109 jobs in Energy:</h1>" in text
+    assert (
+        '<a class="job-link" href="/job/1583065288960216">Interior Designer</a>' in text
+    )
+    assert 'href="/jobs/4?page=2">Next' in text
+
+
+async def test_extract_job_posting(zyte_api_client, jobs_website):
+    url = str(jobs_website.make_url("/job/1888448280485890"))
+    response_data = await zyte_api_client.get(
+        {
+            "url": url,
+            "httpResponseBody": True,
+            "jobPosting": True,
+        },
+    )
+
+    assert "httpResponseBody" in response_data
+    text = b64decode(response_data["httpResponseBody"]).decode("utf-8")
+    assert "<h1>Litigation Attorney</h1>" in text
+    assert '<span class="job-location">Bogotá, Colombia</span>' in text
+
+    assert "jobPosting" in response_data
+    job_posting = response_data["jobPosting"]
+    descr = (
+        "Family Law Attorneys deal with legal matters related to family"
+        " relationships. They handle cases like divorce, child custody,"
+        " adoption, and domestic disputes to provide legal guidance."
+    )
+    assert job_posting == {
+        "url": url,
+        "datePublished": "2023-09-07T00:00:00Z",
+        "datePublishedRaw": "Sep 07, 2023",
+        "jobTitle": "Litigation Attorney",
+        "jobLocation": {"raw": "Bogotá, Colombia"},
+        "description": descr,
+        "descriptionHtml": f"<article>\n\n<p>{descr}</p>\n\n</article>",
+        "employmentType": "Contract",
+        "baseSalary": {"valueMin": "63K", "valueMax": "101K", "currency": "USD"},
+        "requirements": ["4 to 10 Years"],
+        "hiringOrganization": {"name": "Drax Group"},
+        "metadata": {
+            "dateDownloaded": job_posting["metadata"]["dateDownloaded"],
+            "probability": 1.0,
+        },
+    }
+
+
+async def test_extract_job_posting_nav(zyte_api_client, jobs_website):
+    url = jobs_website.make_url("/jobs/4")
+    response_data = await zyte_api_client.get(
+        {
+            "url": str(url),
+            "httpResponseBody": True,
+            "jobPostingNavigation": True,
+        },
+    )
+
+    assert "httpResponseBody" in response_data
+    text = b64decode(response_data["httpResponseBody"]).decode("utf-8")
+    assert "<h1>109 jobs in Energy:</h1>" in text
+
+    assert "jobPostingNavigation" in response_data
+    job_posting_navigation = response_data["jobPostingNavigation"]
+    jobs = [
+        ("1888448280485890", "Litigation Attorney"),
+        ("1583065288960216", "Interior Designer"),
+        ("2505213971303748", "IT Administrator"),
+        ("2973702198556912", "Digital Marketing Specialist"),
+        ("160399666386920", "Legal Assistant"),
+        ("2226428310491314", "Customer Support Specialist"),
+        ("2962173505197183", "Substance Abuse Counselor"),
+        ("895360732760260", "Social Media Manager"),
+        ("360775924046834", "Procurement Manager"),
+        ("1939835498099785", "Physician Assistant"),
+    ]
+    assert job_posting_navigation == {
+        "url": str(url),
+        "items": [
+            {
+                "url": str(url.join(URL(f"/job/{job[0]}"))),
+                "method": "GET",
+                "name": job[1],
+            }
+            for job in jobs
+        ],
+        "nextPage": {"url": str(url.join(URL("/jobs/4?page=2"))), "method": "GET"},
+        "pageNumber": 1,
+        "metadata": {
+            "dateDownloaded": job_posting_navigation["metadata"]["dateDownloaded"]
+        },
+    }

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps =
     pytest
     pytest-aiohttp
     pytest-cov
+    zyte-api
 commands =
     python -m pytest \
         --cov-report=term-missing:skip-covered \

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = py,pre-commit,mypy,twinecheck
 [testenv]
 deps =
     pytest
+    pytest-aiohttp
     pytest-cov
 commands =
     python -m pytest \
@@ -22,7 +23,7 @@ commands = pre-commit run --all-files --show-diff-on-failure
 deps =
     mypy==1.15.0
     pytest
-commands = mypy --strict \
+commands = mypy --strict --implicit-reexport \
     fake_zyte_api tests
 
 [testenv:twinecheck]


### PR DESCRIPTION
- [x] `httpResponseBody` extraction
- [x] `browserHtml` extraction
- [x] `jobPosting` and `jobPostingNavigation` extraction via hardcoded page objects from `zyte_test_websites.jobs.extraction`
- [x] cleanup the tests

I want a separate PR for the registry stuff.

I wonder what should the tests cover. We want test_zyte_api.py as is, but do we want a similarly extensive test_direct.py (in which case the duplicated code needs to be refactored) or should we just test the very basic things in that mode?
